### PR TITLE
Adds flag to use distance between x values when checking for highlight

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -937,6 +937,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// The maximum distance in screen pixels away from an entry causing it to highlight.
     /// **default**: 500.0
     open var maxHighlightDistance: CGFloat = 500.0
+
+    /// Only check distance between the x value of an entry (in screen pixels) causing it to highlight.
+    /// **default**: false
+    open var useHighlightXDistance: Bool = false
     
     /// the number of maximum visible drawn values on the chart only active when `drawValuesEnabled` is enabled
     open var maxVisibleCount: Int

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -56,7 +56,7 @@ open class ChartHighlighter : NSObject, IHighlighter
         
         let axis: YAxis.AxisDependency = leftAxisMinDist < rightAxisMinDist ? .left : .right
         
-        let detail = closestSelectionDetailByPixel(closestValues: closestValues, x: x, y: y, axis: axis, minSelectionDistance: chart.maxHighlightDistance)
+        let detail = closestSelectionDetailByPixel(closestValues: closestValues, x: x, y: y, axis: axis, minSelectionDistance: chart.maxHighlightDistance, usingXDistance: chart.useHighlightXDistance)
         
         return detail
     }
@@ -126,7 +126,8 @@ open class ChartHighlighter : NSObject, IHighlighter
         x: CGFloat,
         y: CGFloat,
         axis: YAxis.AxisDependency?,
-        minSelectionDistance: CGFloat) -> Highlight?
+        minSelectionDistance: CGFloat,
+        usingXDistance: Bool) -> Highlight?
     {
         var distance = minSelectionDistance
         var closest: Highlight?
@@ -135,7 +136,7 @@ open class ChartHighlighter : NSObject, IHighlighter
         {
             if axis == nil || high.axis == axis
             {
-                let cDistance = getDistance(x1: x, y1: y, x2: high.xPx, y2: high.yPx)
+                let cDistance = usingXDistance ? getDistance(x1: x, y1: y, x2: high.xPx, y2: high.yPx) : getXDistance(x1: x, x2: high.xPx)
 
                 if cDistance < distance
                 {
@@ -179,6 +180,11 @@ open class ChartHighlighter : NSObject, IHighlighter
     internal func getDistance(x1: CGFloat, y1: CGFloat, x2: CGFloat, y2: CGFloat) -> CGFloat
     {
         return hypot(x1 - x2, y1 - y2)
+    }
+
+    internal func getXDistance(x1: CGFloat, x2: CGFloat) -> CGFloat
+    {
+        return abs(x1 - x2)
     }
     
     internal var data: ChartData?

--- a/Source/Charts/Interfaces/ChartDataProvider.swift
+++ b/Source/Charts/Interfaces/ChartDataProvider.swift
@@ -28,6 +28,8 @@ public protocol ChartDataProvider
     var chartYMax: Double { get }
     
     var maxHighlightDistance: CGFloat { get }
+
+    var useHighlightXDistance: Bool { get }
     
     var xRange: Double { get }
     


### PR DESCRIPTION
Adds a flag to use the distance between x values when checking for highlight. This will be used in the `PerformanceDeepDiveNode` to get the closest entry to the `indicatorNode` when scrolling the graph. In this case, we only need to know the x position of an entry relative to the `indicatorNode`.