### PR TITLE
Expose getHighlights

### DIFF
--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -31,6 +31,11 @@ open class ChartHighlighter : NSObject, IHighlighter
         let xVal = Double(getValsForTouch(x: x, y: y).x)
         return getHighlight(xValue: xVal, x: x, y: y)
     }
+
+    open func getHighlights(x: CGFloat, y: CGFloat) -> [Highlight]? {
+        let xVal = Double(getValsForTouch(x: x, y: y).x)
+        return getHighlights(xValue: xVal, x: x, y: y)
+    }
     
     /// - returns: The corresponding x-pos for a given touch-position in pixels.
     /// - parameter x:

--- a/Source/Charts/Highlight/IHighlighter.swift
+++ b/Source/Charts/Highlight/IHighlighter.swift
@@ -20,4 +20,9 @@ public protocol IHighlighter: class
     /// - parameter y:
     /// - returns:
     func getHighlight(x: CGFloat, y: CGFloat) -> Highlight?
+
+    /// - returns: A list of Highlight objects corresponding to the given x and y touch position in pixels.
+    /// - parameter x:
+    /// - parameter y:
+    func getHighlights(x: CGFloat, y: CGFloat) -> [Highlight]?
 }


### PR DESCRIPTION
This PR exposes a function to get a list of the closest `Highlight` objects to a given touch point. This will be used in Pace graphs to determine if a gap in data is due to there being no data present or if the data is below the `slowestSupportedPace`.