### PR TITLE
Adds further customizations

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -63,7 +63,10 @@ open class AxisBase: ComponentBase
     private var _limitLines = [ChartLimitLine]()
 
     private var _blocks = [(start: Double, length: Double)]()
-    
+    @objc open var blocksFillColor: CGColor = UIColor.white.cgColor
+    @objc open var blocksStrokeColor: CGColor = UIColor.black.withAlphaComponent(0.1).cgColor
+    @objc open var blockStrokeWidth: CGFloat = 0.5
+    @objc open var blockGradientColors: CFArray = [CGColor]() as CFArray
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
     /// **default**: false

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -66,7 +66,7 @@ open class AxisBase: ComponentBase
     @objc open var blocksFillColor: CGColor = UIColor.white.cgColor
     @objc open var blocksStrokeColor: CGColor = UIColor.black.withAlphaComponent(0.1).cgColor
     @objc open var blockStrokeWidth: CGFloat = 0.5
-    @objc open var blockGradientColors: CFArray = [CGColor]() as CFArray
+    @objc open var blockGradientColors: CFArray = [UIColor.white.cgColor, UIColor.white.withAlphaComponent(0).cgColor] as CFArray
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
     /// **default**: false

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -46,7 +46,7 @@ open class ChartLimitLine: ComponentBase
     @objc open var imageStickyLength = Double(0)
     @objc open var imageTint: UIColor? = nil
     /// Radial Gradient around limit line icons
-    @objc open var radialGradientColors: CFArray = [CGColor]() as CFArray
+    @objc open var radialGradientColors: CFArray = [UIColor.white.withAlphaComponent(0).cgColor, UIColor.white.cgColor] as CFArray
     @objc open var shouldRenderBlockGradient: Bool = true
 
     public override init()

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -44,6 +44,11 @@ open class ChartLimitLine: ComponentBase
     @objc open var imageInsect = UIEdgeInsets.zero
     @objc open var imageSize = CGSize.zero
     @objc open var imageStickyLength = Double(0)
+    @objc open var imageTint: UIColor? = nil
+    /// Radial Gradient around limit line icons
+    @objc open var radialGradientColors: CFArray = [CGColor]() as CFArray
+    @objc open var shouldRenderBlockGradient: Bool = true
+
     public override init()
     {
         super.init()


### PR DESCRIPTION
This PR adds further customizations for `blocks` and `lineLimits`. These customizations include:

- Giving `limitLine`  image a tint
- Specify radial gradient colors around image
- Specify block gradient colors, block background color, block stroke color, and block stroke width
